### PR TITLE
allow changing ccbin

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -26,10 +26,19 @@ fn main() {
       println!("cargo:rustc-link-search=native=/usr/local/cuda/lib64");
     }
 
-    cc::Build::new()
+    
+
+    let mut builder = cc::Build::new();
+    builder
       .cuda(true)
-      .file("src/hvm.cu")
-      .compile("hvm-cu");
+      .file("src/hvm.cu");
+    println!("cargo::rerun-if-env-changed=CUDA_CCBIN");
+    if let Ok(ccbin) = std::env::var("CUDA_CCBIN") {
+      builder
+        .flag("-ccbin")
+        .flag(&ccbin);
+    };
+    builder.compile("hvm-cu");
     
     println!("cargo:rerun-if-changed=src/hvm.cu");
     println!("cargo:rustc-cfg=feature=\"cuda\"");   


### PR DESCRIPTION
`CUDA` may not be buildable with system default `cc`. Add an environment variable to allow users to change `ccbin`.

```
cargo:warning=nvcc warning : incompatible redefinition for option 'compiler-bindir', the last value of this option was used
  cargo:warning=/usr/include/c++/14.1.1/x86_64-pc-linux-gnu/bits/c++config.h(827): error: user-defined literal operator not found
  cargo:warning=    typedef __decltype(0.0bf16) __bfloat16_t;
  cargo:warning=                       ^
  cargo:warning=
  cargo:warning=/usr/include/c++/14.1.1/type_traits(529): error: type name is not allowed
  cargo:warning=      : public __bool_constant<__is_array(_Tp)>
  cargo:warning=                                          ^
  cargo:warning=
  cargo:warning=/usr/include/c++/14.1.1/type_traits(529): error: identifier "__is_array" is undefined
  cargo:warning=      : public __bool_constant<__is_array(_Tp)>
  cargo:warning=                               ^
  cargo:warning=
  cargo:warning=/usr/include/c++/14.1.1/type_traits(581): error: type name is not allowed
  cargo:warning=      : public __bool_constant<__is_member_object_pointer(_Tp)>
  cargo:warning=                                                          ^
  cargo:warning=
  cargo:warning=/usr/include/c++/14.1.1/type_traits(581): error: identifier "__is_member_object_pointer" is undefined
  cargo:warning=      : public __bool_constant<__is_member_object_pointer(_Tp)>
  cargo:warning=                               ^
  cargo:warning=
  cargo:warning=/usr/include/c++/14.1.1/type_traits(603): error: type name is not allowed
  cargo:warning=      : public __bool_constant<__is_member_function_pointer(_Tp)>
  cargo:warning=                                                            ^
  cargo:warning=
  cargo:warning=/usr/include/c++/14.1.1/type_traits(603): error: identifier "__is_member_function_pointer" is undefined
  cargo:warning=      : public __bool_constant<__is_member_function_pointer(_Tp)>
  cargo:warning=                               ^
  cargo:warning=
  cargo:warning=/usr/include/c++/14.1.1/type_traits(695): error: type name is not allowed
  cargo:warning=      : public __bool_constant<__is_reference(_Tp)>
  cargo:warning=                                              ^
  cargo:warning=
  cargo:warning=/usr/include/c++/14.1.1/type_traits(695): error: identifier "__is_reference" is undefined
  cargo:warning=      : public __bool_constant<__is_reference(_Tp)>
  cargo:warning=                               ^
  cargo:warning=
  cargo:warning=/usr/include/c++/14.1.1/type_traits(731): error: type name is not allowed
  cargo:warning=      : public __bool_constant<__is_object(_Tp)>
  cargo:warning=                                           ^
  cargo:warning=
  cargo:warning=/usr/include/c++/14.1.1/type_traits(731): error: identifier "__is_object" is undefined
  cargo:warning=      : public __bool_constant<__is_object(_Tp)>
  cargo:warning=                               ^
  cargo:warning=
  cargo:warning=/usr/include/c++/14.1.1/type_traits(760): error: type name is not allowed
  cargo:warning=      : public __bool_constant<__is_member_pointer(_Tp)>
  cargo:warning=                                                   ^
  cargo:warning=
  cargo:warning=/usr/include/c++/14.1.1/type_traits(760): error: identifier "__is_member_pointer" is undefined
  cargo:warning=      : public __bool_constant<__is_member_pointer(_Tp)>
  cargo:warning=                               ^
  cargo:warning=
  cargo:warning=/usr/include/c++/14.1.1/type_traits(3247): error: type name is not allowed
  cargo:warning=    inline constexpr bool is_array_v = __is_array(_Tp);
  cargo:warning=                                                  ^
  cargo:warning=
  cargo:warning=/usr/include/c++/14.1.1/type_traits(3271): error: type name is not allowed
  cargo:warning=      __is_member_object_pointer(_Tp);
  cargo:warning=                                 ^
  cargo:warning=
  cargo:warning=/usr/include/c++/14.1.1/type_traits(3281): error: type name is not allowed
  cargo:warning=      __is_member_function_pointer(_Tp);
  cargo:warning=                                   ^
  cargo:warning=
  cargo:warning=/usr/include/c++/14.1.1/type_traits(3298): error: type name is not allowed
  cargo:warning=    inline constexpr bool is_reference_v = __is_reference(_Tp);
  cargo:warning=                                                          ^
  cargo:warning=
  cargo:warning=/usr/include/c++/14.1.1/type_traits(3315): error: type name is not allowed
  cargo:warning=    inline constexpr bool is_object_v = __is_object(_Tp);
  cargo:warning=                                                    ^
  cargo:warning=
  cargo:warning=/usr/include/c++/14.1.1/type_traits(3328): error: type name is not allowed
  cargo:warning=    inline constexpr bool is_member_pointer_v = __is_member_pointer(_Tp);
  cargo:warning=                                                                    ^
  cargo:warning=
  cargo:warning=/usr/include/c++/14.1.1/bits/utility.h(237): error: __type_pack_element is not a template
  cargo:warning=      { using type = __type_pack_element<_Np, _Types...>; };
  cargo:warning=                     ^
  cargo:warning=
  cargo:warning=20 errors detected in the compilation of "src/hvm.cu".
  ```