### PR TITLE
Readback results from HVM into Rust through interop

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -364,7 +364,7 @@ impl Book {
 // --------
 
 impl Tree {
-  pub fn readback<N: interop::NetReadback>(net: &N, port: hvm::Port, fids: &BTreeMap<hvm::Val, String>) -> Option<Tree> {
+  pub fn readback<N: interop::NetReadback>(net: &mut N, port: hvm::Port, fids: &BTreeMap<hvm::Val, String>) -> Option<Tree> {
     //println!("reading {}", port.show());
     match port.get_tag() {
       hvm::VAR => {
@@ -416,7 +416,7 @@ impl Tree {
 }
 
 impl Net {
-  pub fn readback<N: interop::NetReadback>(net: &N, book: &hvm::Book) -> Option<Net> {
+  pub fn readback<N: interop::NetReadback>(net: &mut N, book: &hvm::Book) -> Option<Net> {
     let mut fids = BTreeMap::new();
     for (fid, def) in book.defs.iter().enumerate() {
       fids.insert(fid as hvm::Val, def.name.clone());

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,6 +1,6 @@
 use TSPL::{new_parser, Parser};
 use highlight_error::highlight_error;
-use crate::hvm;
+use crate::{hvm, interop};
 use std::{collections::BTreeMap, fmt::{Debug, Display}};
 
 // Types
@@ -363,7 +363,7 @@ impl Book {
 // --------
 
 impl Tree {
-  pub fn readback(net: &hvm::GNet, port: hvm::Port, fids: &BTreeMap<hvm::Val, String>) -> Option<Tree> {
+  pub fn readback<N: interop::NetReadback>(net: &N, port: hvm::Port, fids: &BTreeMap<hvm::Val, String>) -> Option<Tree> {
     //println!("reading {}", port.show());
     match port.get_tag() {
       hvm::VAR => {
@@ -415,7 +415,7 @@ impl Tree {
 }
 
 impl Net {
-  pub fn readback(net: &hvm::GNet, book: &hvm::Book) -> Option<Net> {
+  pub fn readback<N: interop::NetReadback>(net: &N, book: &hvm::Book) -> Option<Net> {
     let mut fids = BTreeMap::new();
     for (fid, def) in book.defs.iter().enumerate() {
       fids.insert(fid as hvm::Val, def.name.clone());

--- a/src/hvm.c
+++ b/src/hvm.c
@@ -1786,6 +1786,10 @@ void hvm_c(u32* book_buffer, Net* net_buffer) {
 
   #ifdef IO
   do_run_io(net, book, ROOT);
+  // IO actions into `stdout` and `stderr` may appear
+  // after Rust `print`s if we don't flush
+  fflush(stdout);
+  fflush(stderr);
   #else
   normalize(net, book);
   #endif

--- a/src/hvm.c
+++ b/src/hvm.c
@@ -1757,8 +1757,7 @@ void do_run_io(Net* net, Book* book, Port port);
 
 // Main
 // ----
-
-void hvm_c(u32* book_buffer) {
+void hvm_c(u32* book_buffer, Net* net_buffer) {
   // Creates static TMs
   alloc_static_tms();
 
@@ -1773,7 +1772,13 @@ void hvm_c(u32* book_buffer) {
   u64 start = time64();
 
   // GMem
-  Net *net = malloc(sizeof(Net));
+  Net *net;
+  if (net_buffer) {
+    // A buffer for the net has been allocated externally
+    net = net_buffer;
+  } else {
+    net = malloc(sizeof(Net));
+  }
   net_init(net);
 
   // Creates an initial redex that calls main
@@ -1801,13 +1806,13 @@ void hvm_c(u32* book_buffer) {
 
   // Frees everything
   free_static_tms();
-  free(net);
+  if (!net_buffer) { free(net); }
   free(book);
 }
 
 #ifdef WITH_MAIN
 int main() {
-  hvm_c((u32*)BOOK_BUF);
+  hvm_c((u32*)BOOK_BUF, NULL);
   return 0;
 }
 #endif

--- a/src/hvm.c
+++ b/src/hvm.c
@@ -1790,19 +1790,21 @@ void hvm_c(u32* book_buffer, Net* net_buffer) {
   normalize(net, book);
   #endif
 
-  // Prints the result
-  printf("Result: ");
-  pretty_print_port(net, book, enter(net, ROOT));
-  printf("\n");
-
   // Stops the timer
   double duration = (time64() - start) / 1000000000.0; // seconds
 
-  // Prints interactions and time
-  u64 itrs = atomic_load(&net->itrs);
-  printf("- ITRS: %" PRIu64 "\n", itrs);
-  printf("- TIME: %.2fs\n", duration);
-  printf("- MIPS: %.2f\n", (double)itrs / duration / 1000000.0);
+  if (!net_buffer) {
+    // Prints the result
+    printf("Result: ");
+    pretty_print_port(net, book, enter(net, ROOT));
+    printf("\n");
+  
+    // Prints interactions and time
+    u64 itrs = atomic_load(&net->itrs);
+    printf("- ITRS: %" PRIu64 "\n", itrs);
+    printf("- TIME: %.2fs\n", duration);
+    printf("- MIPS: %.2f\n", (double)itrs / duration / 1000000.0);
+  }
 
   // Frees everything
   free_static_tms();

--- a/src/hvm.c
+++ b/src/hvm.c
@@ -1765,7 +1765,7 @@ typedef struct OutputNet {
   a64 itrs;
 } OutputNet;
 
-void free_output_net(OutputNet* net) {
+void free_output_net_c(OutputNet* net) {
   free((Net*)net->original);
   free(net);
 }

--- a/src/hvm.cu
+++ b/src/hvm.cu
@@ -2296,7 +2296,7 @@ __global__ void compact(GNet* gnet, Pair* node_out, Port* vars_out) {
 void do_run_io(GNet* gnet, Book* book, Port port);
 #endif
 
-extern "C" void hvm_cu(u32* book_buffer, GNet* output) {
+extern "C" void hvm_cu(u32* book_buffer, bool return_output) {
   // Start the timer
   clock_t start = clock();
 
@@ -2330,7 +2330,7 @@ extern "C" void hvm_cu(u32* book_buffer, GNet* output) {
 
   // Prints the result
   // If `output` is set, the Rust implementation will print the net
-  if (!output) {
+  if (!return_output) {
     print_result<<<1,1>>>(gnet);
   }
 
@@ -2345,8 +2345,8 @@ extern "C" void hvm_cu(u32* book_buffer, GNet* output) {
   }
 
   // If `output` is set, copy the memory from the net into the Rust implementation
-  if (output) {
-    cudaMemcpy(output, gnet, sizeof(GNet), cudaMemcpyDeviceToHost);
+  if (return_output) {
+    // cudaMemcpy(output, gnet, sizeof(GNet), cudaMemcpyDeviceToHost);
   }
 
   // Prints entire memdump
@@ -2374,7 +2374,7 @@ extern "C" void hvm_cu(u32* book_buffer, GNet* output) {
 
   // Prints interactions, time and MIPS
   // If `output` is set, the Rust implementation will print the net
-  if (!output) {
+  if (!return_output) {
     printf("- ITRS: %llu\n", gnet_get_itrs(gnet));
     printf("- LEAK: %llu\n", gnet_get_leak(gnet));
     printf("- TIME: %.2fs\n", duration);

--- a/src/hvm.rs
+++ b/src/hvm.rs
@@ -12,15 +12,19 @@ pub type Val  = u32; // Val  ::= 29-bit (rounded up to u32)
 pub type Rule = u8;  // Rule ::= 8-bit (fits a u8)
 
 // Port
+#[repr(C)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Hash)]
 pub struct Port(pub Val);
 
 // Pair
+#[repr(C)]
 pub struct Pair(pub u64);
 
 // Atomics
 pub type AVal = AtomicU32;
+#[repr(C)]
 pub struct APort(pub AVal);
+#[repr(C)]
 pub struct APair(pub AtomicU64);
 
 // Number

--- a/src/interop.rs
+++ b/src/interop.rs
@@ -5,12 +5,12 @@ use crate::hvm::*;
 
 #[cfg(feature = "c")]
 extern "C" {
-  fn hvm_c(book_buffer: *const u32, net_buffer: *const RawNetC);
+  pub fn hvm_c(book_buffer: *const u32, net_buffer: *const RawNetC);
 }
 
 #[cfg(feature = "cuda")]
 extern "C" {
-  fn hvm_cu(book_buffer: *const u32);
+  pub fn hvm_cu(book_buffer: *const u32, net_buffer: *const RawNetCuda);
 }
 
 // Abstract Global Net
@@ -159,3 +159,70 @@ impl NetReadback for NetC {
 // TODO
 // Problem: CUDA's `GNet` is allocated using `cudaMalloc`
 // Solution: Write a CUDA kernel to compact GPU memory and then `memcpy` it to RAM
+
+// #[cfg(feature = "cuda")]
+#[repr(C)]
+pub struct NetCuda {
+  raw: *mut RawNetCuda
+}
+
+// #[cfg(feature = "cuda")]
+#[repr(C)]
+pub struct RawNetCuda {
+  pub rbag_use_a: u32, // total rbag redex count (buffer A)
+  pub rbag_use_b: u32, // total rbag redex count (buffer B)
+  pub rbag_buf_a: [Pair; NetCuda::G_RBAG_LEN], // global redex bag (buffer A)
+  pub rbag_buf_b: [Pair; NetCuda::G_RBAG_LEN], // global redex bag (buffer B)
+  pub node_buf: [Pair; NetCuda::G_NODE_LEN], // global node buffer
+  pub vars_buf: [Port; NetCuda::G_VARS_LEN], // global vars buffer
+  pub node_put: [u32; NetCuda::TPB * NetCuda::BPG],
+  pub vars_put: [u32; NetCuda::TPB * NetCuda::BPG],
+  pub rbag_put: [u32; NetCuda::TPB * NetCuda::BPG],
+  pub mode: u8, // evaluation mode (curr)
+  pub itrs: u64, // interaction count
+  pub iadd: u64, // interaction count adder
+  pub leak: u64, // leak count
+  pub turn: u32, // turn count
+  pub down: u8, // are we recursing down?
+  pub rdec: u8, // decrease rpos by 1?
+}
+
+// #[cfg(feature = "cuda")]
+impl NetCuda {
+  // Constants relevant in the CUDA implementation
+  // NOTE: If any of these constants are changed in CUDA, they have to be changed here as well.
+  
+  // Threads per Block
+  pub const TPB_L2: usize = 7;
+  pub const TPB: usize    = 1 << NetCuda::TPB_L2;
+  
+  // Blocks per GPU
+  pub const BPG_L2: usize = 7;
+  pub const BPG: usize    = 1 << NetCuda::BPG_L2;
+
+  // Thread Redex Bag Length
+  pub const RLEN: usize   = 256;
+
+  pub const G_NODE_LEN: usize = 1 << 29; // max 536m nodes
+  pub const G_VARS_LEN: usize = 1 << 29; // max 536m vars
+  pub const G_RBAG_LEN: usize = NetCuda::TPB * NetCuda::BPG * NetCuda::RLEN * 3;
+
+  pub fn net(&self) -> &RawNetCuda {
+    unsafe { &*self.raw }
+  }
+
+  pub fn net_mut(&mut self) -> &mut RawNetCuda {
+    unsafe { &mut *self.raw }
+  }
+
+  fn vars_exchange(&mut self, var: usize, val: Port) -> Port {
+    let net = self.net_mut();
+    let old = net.vars_buf[var];
+    net.vars_buf[var] = val;
+    old
+  }
+
+  pub fn vars_take(&mut self, var: usize) -> Port {
+    self.vars_exchange(var, Port(0))
+  }
+}

--- a/src/interop.rs
+++ b/src/interop.rs
@@ -1,0 +1,91 @@
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+
+use crate::hvm::*;
+
+// Abstract Global Net
+// Allows any global net to be read back
+// -------------
+
+pub trait NetReadback {
+  fn enter(&self, var: Port) -> Port;
+  fn node_load(&self, loc: usize) -> Pair;
+}
+
+impl<'a> NetReadback for GNet<'a> {
+  fn enter(&self, var: Port) -> Port { self.enter(var) }
+  fn node_load(&self, loc: usize) -> Pair { self.node_load(loc) }
+}
+
+// Global Net equivalent to the C implementation.
+// NOTE: If the C struct `Net` changes, this has to change as well.
+// TODO: use `bindgen` crate (https://github.com/rust-lang/rust-bindgen) to generate C structs
+// -------------
+
+#[repr(C)]
+pub struct NetC {
+  pub node: [APair; NetC::G_NODE_LEN], // global node buffer
+  pub vars: [APort; NetC::G_VARS_LEN], // global vars buffer
+  pub rbag: [APair; NetC::G_RBAG_LEN], // global rbag buffer
+  pub itrs: AtomicU64, // interaction count
+  pub idle: AtomicU32, // idle thread counter
+}
+
+impl NetC {
+  // Constants relevant in the C implementation
+  // NOTE: If any of these constants are changed in C, they have to be changed here as well.
+  pub const TPC_L2: usize = 3;
+  pub const TPC: usize = 1 << NetC::TPC_L2;
+  pub const CACHE_PAD: usize = 64; // Cache padding
+
+  pub const HLEN: usize = 1 << 16; // max 16k high-priority redexes
+  pub const RLEN: usize = 1 << 24; // max 16m low-priority redexes
+  pub const G_NODE_LEN: usize = 1 << 29; // max 536m nodes
+  pub const G_VARS_LEN: usize = 1 << 29; // max 536m vars
+  pub const G_RBAG_LEN: usize = NetC::TPC * NetC::RLEN;
+
+  pub fn vars_exchange(&self, var: usize, val: Port) -> Port {
+    Port(self.vars[var].0.swap(val.0, Ordering::Relaxed) as u32)
+  }
+
+  pub fn vars_take(&self, var: usize) -> Port {
+    self.vars_exchange(var, Port(0))
+  }
+
+  fn node_load(&self, loc:usize) -> Pair {
+    Pair(self.node[loc].0.load(Ordering::Relaxed))
+  }
+
+  fn enter(&self, mut var: Port) -> Port {
+    // While `B` is VAR: extend it (as an optimization)
+    while var.get_tag() == VAR {
+      // Takes the current `B` substitution as `B'`
+      let val = self.vars_exchange(var.get_val() as usize, NONE);
+      // If there was no `B'`, stop, as there is no extension
+      if val == NONE || val == Port(0) {
+        break;
+      }
+      // Otherwise, delete `B` (we own both) and continue as `A ~> B'`
+      self.vars_take(var.get_val() as usize);
+      var = val;
+    }
+    return var;
+  }
+}
+
+impl NetReadback for NetC {
+  fn node_load(&self, loc:usize) -> Pair {
+    self.node_load(loc)
+  }
+  
+  fn enter(&self, var: Port) -> Port {
+    self.enter(var)
+  } 
+}
+
+// Global Net equivalent to the CUDA implementation.
+// NOTE: If the CUDA struct `Net` changes, this has to change as well.
+// -------------
+
+// TODO
+// Problem: CUDA's `GNet` is allocated using `cudaMalloc`
+// Solution: Write a CUDA kernel to compact GPU memory and then `memcpy` it to RAM

--- a/src/interop.rs
+++ b/src/interop.rs
@@ -1,19 +1,52 @@
+use std::alloc;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 
 use crate::hvm::*;
+
+#[cfg(feature = "c")]
+extern "C" {
+  fn hvm_c(book_buffer: *const u32, net_buffer: *const NetC, run_io: bool);
+}
+
+#[cfg(feature = "cuda")]
+extern "C" {
+  fn hvm_cu(book_buffer: *const u32, run_io: bool);
+}
 
 // Abstract Global Net
 // Allows any global net to be read back
 // -------------
 
 pub trait NetReadback {
+  fn run<T>(book: &Book, before: impl FnOnce() -> T, after: impl FnOnce(&Self, &Book, T) -> ());
   fn enter(&self, var: Port) -> Port;
   fn node_load(&self, loc: usize) -> Pair;
+  fn itrs(&self) -> u64;
 }
 
 impl<'a> NetReadback for GNet<'a> {
+  fn run<T>(book: &Book, before: impl FnOnce() -> T, after: impl FnOnce(&Self, &Book, T) -> ()) {
+    // Initializes the global net
+    let net = GNet::new(1 << 29, 1 << 29);
+
+    // Initializes threads
+    let mut tm = TMem::new(0, 1);
+
+    // Creates an initial redex that calls main
+    let main_id = book.defs.iter().position(|def| def.name == "main").unwrap();
+    tm.rbag.push_redex(Pair::new(Port::new(REF, main_id as u32), ROOT));
+    net.vars_create(ROOT.get_val() as usize, NONE);
+
+    let initial_state = before();
+
+    // Evaluates
+    tm.evaluator(&net, &book);
+
+    after(&net, book, initial_state);
+  }
   fn enter(&self, var: Port) -> Port { self.enter(var) }
   fn node_load(&self, loc: usize) -> Pair { self.node_load(loc) }
+  fn itrs(&self) -> u64 { self.itrs.load(Ordering::Relaxed) }
 }
 
 // Global Net equivalent to the C implementation.
@@ -21,6 +54,7 @@ impl<'a> NetReadback for GNet<'a> {
 // TODO: use `bindgen` crate (https://github.com/rust-lang/rust-bindgen) to generate C structs
 // -------------
 
+#[cfg(feature = "c")]
 #[repr(C)]
 pub struct NetC {
   pub node: [APair; NetC::G_NODE_LEN], // global node buffer
@@ -30,6 +64,7 @@ pub struct NetC {
   pub idle: AtomicU32, // idle thread counter
 }
 
+#[cfg(feature = "c")]
 impl NetC {
   // Constants relevant in the C implementation
   // NOTE: If any of these constants are changed in C, they have to be changed here as well.
@@ -72,14 +107,35 @@ impl NetC {
   }
 }
 
+#[cfg(feature = "c")]
 impl NetReadback for NetC {
-  fn node_load(&self, loc:usize) -> Pair {
-    self.node_load(loc)
+  fn run<T>(book: &Book, before: impl FnOnce() -> T, after: impl FnOnce(&Self, &Book, T) -> ()) {
+    // Serialize book
+    let mut data : Vec<u8> = Vec::new();
+    book.to_buffer(&mut data);
+    //println!("{:?}", data);
+    let book_buffer = data.as_mut_ptr() as *mut u32;
+
+    let layout = alloc::Layout::new::<NetC>();
+    let net_ptr = unsafe { alloc::alloc(layout) as *mut NetC };
+
+    let initial_state = before();
+
+    unsafe {
+      hvm_c(data.as_mut_ptr() as *mut u32, net_ptr, true);
+    }
+
+    // Converts the raw pointer to a reference
+    let net_ref = unsafe { &mut *net_ptr };
+
+    after(net_ref, book, initial_state);
+
+    // Deallocate network's memory
+    unsafe { alloc::dealloc(net_ptr as *mut u8, layout) };
   }
-  
-  fn enter(&self, var: Port) -> Port {
-    self.enter(var)
-  } 
+  fn node_load(&self, loc:usize) -> Pair { self.node_load(loc) }
+  fn enter(&self, var: Port) -> Port { self.enter(var) } 
+  fn itrs(&self) -> u64 { self.itrs.load(Ordering::Relaxed) }
 }
 
 // Global Net equivalent to the CUDA implementation.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,4 @@
 pub mod ast;
 pub mod cmp;
 pub mod hvm;
+pub mod interop;

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,9 +79,7 @@ fn main() {
       let mut data : Vec<u8> = Vec::new();
       book.to_buffer(&mut data);
       #[cfg(feature = "cuda")]
-      unsafe {
-        interop::hvm_cu(data.as_mut_ptr() as *mut u32, std::ptr::null());
-      }
+      run::<interop::NetCuda>(&book);
       #[cfg(not(feature = "cuda"))]
       println!("CUDA runtime not available!\n If you've installed CUDA and nvcc after HVM, please reinstall HVM.");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,6 @@ fn main() {
       let code = fs::read_to_string(file).expect("Unable to read file");
       let book = ast::Book::parse(&code).unwrap_or_else(|er| panic!("{}",er)).build();
       hvm::GNet::run(&book, before_running, after_running);
-      // run(&book);
     }
     Some(("run-c", sub_matches)) => {
       let file = sub_matches.get_one::<String>("file").expect("required");

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,16 +11,6 @@ use std::path::PathBuf;
 use std::time::Instant;
 use std::process::Command as SysCommand;
 
-#[cfg(feature = "c")]
-extern "C" {
-  fn hvm_c(book_buffer: *const u32, net_buffer: *const interop::NetC);
-}
-
-#[cfg(feature = "cuda")]
-extern "C" {
-  fn hvm_cu(book_buffer: *const u32);
-}
-
 fn main() {
   let matches = Command::new("hvm")
     .about("HVM2: Higher-order Virtual Machine 2 (32-bit Version)")
@@ -90,7 +80,7 @@ fn main() {
       book.to_buffer(&mut data);
       #[cfg(feature = "cuda")]
       unsafe {
-        hvm_cu(data.as_mut_ptr() as *mut u32);
+        interop::hvm_cu(data.as_mut_ptr() as *mut u32, std::ptr::null());
       }
       #[cfg(not(feature = "cuda"))]
       println!("CUDA runtime not available!\n If you've installed CUDA and nvcc after HVM, please reinstall HVM.");
@@ -159,7 +149,7 @@ pub fn run<N: NetReadback>(book: &hvm::Book) {
   // Start timer
   let timer = Instant::now();
 
-  // Run net
+  // Normalize net
   let net = N::run(book);
   
   // Stops the timer

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,15 +71,14 @@ fn main() {
       let file = sub_matches.get_one::<String>("file").expect("required");
       let code = fs::read_to_string(file).expect("Unable to read file");
       let book = ast::Book::parse(&code).unwrap_or_else(|er| panic!("{}",er)).build();
-      hvm::GNet::run(&book, before_running, after_running);
+      run::<hvm::GNet>(&book);
     }
     Some(("run-c", sub_matches)) => {
       let file = sub_matches.get_one::<String>("file").expect("required");
       let code = fs::read_to_string(file).expect("Unable to read file");
       let book = ast::Book::parse(&code).unwrap_or_else(|er| panic!("{}",er)).build();
-      let run_io = sub_matches.get_flag("io");
       #[cfg(feature = "c")]
-      interop::NetC::run(&book, before_running, after_running);
+      run::<interop::NetC>(&book);
       #[cfg(not(feature = "c"))]
       println!("C runtime not available!\n");
     }
@@ -156,18 +155,20 @@ fn main() {
   }
 }
 
-pub fn before_running() -> Instant {
-  Instant::now()
-}
+pub fn run<N: NetReadback>(book: &hvm::Book) {
+  // Start timer
+  let timer = Instant::now();
 
-pub fn after_running(net: &impl interop::NetReadback, book: &hvm::Book, timer: Instant) {
+  // Run net
+  let net = N::run(book);
+  
   // Stops the timer
   let duration = timer.elapsed();
 
   //println!("{}", net.show());
 
   // Prints the result
-  if let Some(tree) = ast::Net::readback(net, book) {
+  if let Some(tree) = ast::Net::readback(&net, book) {
     println!("Result: {}", tree.show());
   } else {
     println!("Readback failed. Printing GNet memdump...\n");
@@ -180,83 +181,3 @@ pub fn after_running(net: &impl interop::NetReadback, book: &hvm::Book, timer: I
   println!("- TIME: {:.2}s", duration.as_secs_f64());
   println!("- MIPS: {:.2}", itrs as f64 / duration.as_secs_f64() / 1_000_000.0);
 }
-
-// pub fn run(book: &hvm::Book) {
-//   // Initializes the global net
-//   let net = hvm::GNet::new(1 << 29, 1 << 29);
-
-//   // Initializes threads
-//   let mut tm = hvm::TMem::new(0, 1);
-
-//   // Creates an initial redex that calls main
-//   let main_id = book.defs.iter().position(|def| def.name == "main").unwrap();
-//   tm.rbag.push_redex(hvm::Pair::new(hvm::Port::new(hvm::REF, main_id as u32), hvm::ROOT));
-//   net.vars_create(hvm::ROOT.get_val() as usize, hvm::NONE);
-
-//   // Starts the timer
-//   let start = std::time::Instant::now();
-
-//   // Evaluates
-//   tm.evaluator(&net, &book);
-  
-//   // Stops the timer
-//   let duration = start.elapsed();
-
-//   //println!("{}", net.show());
-
-//   // Prints the result
-//   if let Some(tree) = ast::Net::readback(&net, book) {
-//     println!("Result: {}", tree.show());
-//   } else {
-//     println!("Readback failed. Printing GNet memdump...\n");
-//     println!("{}", net.show());
-//   }
-
-//   // Prints interactions and time
-//   let itrs = net.itrs.load(std::sync::atomic::Ordering::Relaxed);
-//   println!("- ITRS: {}", itrs);
-//   println!("- TIME: {:.2}s", duration.as_secs_f64());
-//   println!("- MIPS: {:.2}", itrs as f64 / duration.as_secs_f64() / 1_000_000.0);
-// }
-
-// #[cfg(feature = "c")]
-// pub fn run_c(book: &hvm::Book) {
-//   // Serialize book
-//   let mut data : Vec<u8> = Vec::new();
-//   book.to_buffer(&mut data);
-//   //println!("{:?}", data);
-//   let book_buffer = data.as_mut_ptr() as *mut u32;
-
-//   let layout = alloc::Layout::new::<interop::NetC>();
-//   let net_ptr = unsafe { alloc::alloc(layout) as *mut interop::NetC };
-
-//   // Starts the timer
-//   let start = std::time::Instant::now();
-
-//   unsafe {
-//     hvm_c(data.as_mut_ptr() as *mut u32, net_ptr, true);
-//   }
-
-//   // Stops the timer
-//   let duration = start.elapsed();
- 
-//   // Converts the raw pointer to a reference
-//   let net_ref = unsafe { &mut *net_ptr };
- 
-//   // Prints the result
-//   if let Some(tree) = ast::Net::readback(net_ref, book) {
-//     println!("Result: {}", tree.show());
-//   } else {
-//     println!("Readback failed. Can't print GNet memdump from C.\n");
-//     // println!("{}", net_ref.show());
-//   }
- 
-//   // Prints interactions and time
-//   let itrs = net_ref.itrs.load(std::sync::atomic::Ordering::Relaxed);
-//   println!("- ITRS: {}", itrs);
-//   println!("- TIME: {:.2}s", duration.as_secs_f64());
-//   println!("- MIPS: {:.2}", itrs as f64 / duration.as_secs_f64() / 1_000_000.0);
- 
-//   // Deallocate network's memory
-//   unsafe { alloc::dealloc(net_ptr as *mut u8, layout) };
-// }

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,7 +150,7 @@ pub fn run<N: NetReadback>(book: &hvm::Book) {
   let timer = Instant::now();
 
   // Normalize net
-  let net = N::run(book);
+  let mut net = N::run(book);
   
   // Stops the timer
   let duration = timer.elapsed();
@@ -158,7 +158,7 @@ pub fn run<N: NetReadback>(book: &hvm::Book) {
   //println!("{}", net.show());
 
   // Prints the result
-  if let Some(tree) = ast::Net::readback(&net, book) {
+  if let Some(tree) = ast::Net::readback(&mut net, book) {
     println!("Result: {}", tree.show());
   } else {
     println!("Readback failed. Printing GNet memdump...\n");


### PR DESCRIPTION
This allows the resulting nets to be read back directly from Rust, without requiring each implementation to print it's networks in error-prone ways.

TODO: The CUDA version is still quite slow due to copying the entire `GNet` into the host from the device. The way to fix it is to compact the global network's memory and only copy the relevant portion before copying it into RAM.