### PR TITLE
add book_load warnings, arbitrary-size strings/bytes

### DIFF
--- a/src/hvm.c
+++ b/src/hvm.c
@@ -10,7 +10,7 @@
 #ifdef DEBUG
   #define debug(...) fprintf(stderr, __VA_ARGS__)
 #else
-  #define debug(x)
+  #define debug(...)
 #endif
 
 #define INTERPRETED
@@ -596,7 +596,7 @@ static inline void push_redex(Net* net, TM* tm, Pair redex) {
   bool free_local = tm->hput < HLEN;
   bool free_global = tm->rput < RLEN;
   if (!free_global || !free_local) {
-    debugln("push_redex: limited resources, maybe corrupting memory\n");
+    debug("push_redex: limited resources, maybe corrupting memory\n");
   }
   #endif
 

--- a/src/hvm.c
+++ b/src/hvm.c
@@ -1435,12 +1435,12 @@ bool book_load(Book* book, u32* buf) {
     def->node_len = *buf++;
     def->vars_len = *buf++;
 
-    if (def->rbag_len >= DEF_RBAG_LEN) {
+    if (def->rbag_len > DEF_RBAG_LEN) {
       fprintf(stderr, "def '%s' has too many redexes: %u\n", def->name, def->rbag_len);
       return FALSE;
     }
 
-    if (def->node_len >= DEF_NODE_LEN) {
+    if (def->node_len > DEF_NODE_LEN) {
       fprintf(stderr, "def '%s' has too many nodes: %u\n", def->name, def->node_len);
       return FALSE;
     }

--- a/src/hvm.c
+++ b/src/hvm.c
@@ -1755,7 +1755,7 @@ void hvm_c(u32* book_buffer) {
   if (book_buffer) {
     book = (Book*)malloc(sizeof(Book));
     if (!book_load(book, book_buffer)) {
-      fprintf(stderr, "failed to load book, quitting\n");
+      fprintf(stderr, "failed to load book\n");
 
       return;
     }

--- a/src/hvm.c
+++ b/src/hvm.c
@@ -703,14 +703,13 @@ static inline Port vars_take(Net* net, u32 var) {
 // ---
 
 // Initializes a net.
-static inline void net_init(Net* net) {
-  // is that needed?
+static inline Net* net_new() {
+  Net* net = calloc(1, sizeof(Net));
+
   atomic_store(&net->itrs, 0);
   atomic_store(&net->idle, 0);
 
-  memset(net->node_buf, 0, G_NODE_LEN);
-  memset(net->vars_buf, 0, G_VARS_LEN);
-  memset(net->rbag_buf, 0, G_RBAG_LEN);
+  return net;
 }
 
 // Allocator
@@ -1762,8 +1761,7 @@ void hvm_c(u32* book_buffer) {
   }
 
   // GMem
-  Net *net = malloc(sizeof(Net));
-  net_init(net);
+  Net *net = net_new();
 
   // Starts the timer
   u64 start = time64();

--- a/src/hvm.cu
+++ b/src/hvm.cu
@@ -1915,12 +1915,12 @@ bool book_load(Book* book, u32* buf) {
     def->node_len = *buf++;
     def->vars_len = *buf++;
 
-    if (def->rbag_len >= L_NODE_LEN/TPB) {
+    if (def->rbag_len > L_NODE_LEN/TPB) {
       fprintf(stderr, "def '%s' has too many redexes: %u\n", def->name, def->rbag_len);
       return FALSE;
     }
 
-    if (def->node_len >= L_NODE_LEN/TPB) {
+    if (def->node_len > L_NODE_LEN/TPB) {
       fprintf(stderr, "def '%s' has too many nodes: %u\n", def->name, def->node_len);
       return FALSE;
     }

--- a/src/run.c
+++ b/src/run.c
@@ -504,9 +504,9 @@ Port io_dl_open(Net* net, Book* book, Port argm) {
 
   for (u32 dl = 0; dl < sizeof(DYLIBS); dl++) {
     if (DYLIBS[dl] == NULL) {
-      DYLIBS[dl] = dlopen(str.text_buf, flags);
+      DYLIBS[dl] = dlopen(str.buf, flags);
       if (DYLIBS[dl] == NULL) {
-        fprintf(stderr, "failed to open dylib '%s': %s\n", str.text_buf, dlerror());
+        fprintf(stderr, "failed to open dylib '%s': %s\n", str.buf, dlerror());
 
         return new_port(ERA, 0);
       }
@@ -535,10 +535,10 @@ Port io_dl_call(Net* net, Book* book, Port argm) {
   Str symbol = readback_str(net, book, tup.elem_buf[1]);
 
   dlerror();
-  Port (*func)(Net*, Book*, Port) = dlsym(dl, symbol.text_buf);
+  Port (*func)(Net*, Book*, Port) = dlsym(dl, symbol.buf);
   char* error = dlerror();
   if (error != NULL) {
-    fprintf(stderr, "io_dl_call: failed to get symbol '%s': %s\n", symbol.text_buf, error);
+    fprintf(stderr, "io_dl_call: failed to get symbol '%s': %s\n", symbol.buf, error);
   }
 
   return func(net, book, tup.elem_buf[2]);

--- a/src/run.c
+++ b/src/run.c
@@ -124,10 +124,7 @@ Bytes readback_bytes(Net* net, Book* book, Port port) {
 
         if (bytes.len == capacity - 1) {
           capacity *= 2;
-          char* new_buf = malloc(sizeof(char) * capacity);
-          memcpy(new_buf, bytes.buf, bytes.len);
-          free(bytes.buf);
-          bytes.buf = new_buf;
+          bytes.buf = realloc(bytes.buf, capacity);
         }
 
         bytes.buf[bytes.len++] = get_u24(get_val(ctr.args_buf[0]));

--- a/src/run.c
+++ b/src/run.c
@@ -162,8 +162,7 @@ Str readback_str(Net* net, Book* book, Port port) {
 }
 
 /// Returns a λ-Encoded Ctr for a NIL: λt (t NIL)
-/// Should only be called within `inject_bytes`, as a previous call
-/// to `get_resources` is expected.
+/// A previous call to `get_resources(tm, 0, 2, 1)` is required.
 Port inject_nil(Net* net) {
   u32 v1 = tm[0]->vloc[0];
 
@@ -180,11 +179,7 @@ Port inject_nil(Net* net) {
 }
 
 /// Returns a λ-Encoded Ctr for a CONS: λt (((t CONS) head) tail)
-/// Should only be called within `inject_bytes`, as a previous call
-/// to `get_resources` is expected.
-/// The `char_idx` parameter is used to offset the vloc and nloc
-/// allocations, otherwise they would conflict with each other on
-/// subsequent calls.
+/// A previous call to `get_resources(tm, 0, 4, 1)` is required.
 Port inject_cons(Net* net, Port head, Port tail) {
   u32 v1 = tm[0]->vloc[0];
 
@@ -219,7 +214,7 @@ Port inject_bytes(Net* net, Bytes *bytes) {
   }
   Port port = inject_nil(net);
 
-  // TODO: batch allocate these (within the limits of TM)
+  // TODO: batch-allocate these (within the limits of TM)
   for (u32 i = 0; i < len; i++) {
     if (!get_resources(net, tm[0], 0, 4, 1)) {
       fprintf(stderr, "inject_bytes: failed to get resources\n");

--- a/src/run.cu
+++ b/src/run.cu
@@ -122,12 +122,10 @@ Bytes gnet_readback_bytes(GNet* gnet, Port port) {
       case LIST_CONS: {
         if (ctr.args_len != 2) break;
         if (get_tag(ctr.args_buf[0]) != NUM) break;
+
         if (bytes.len == capacity - 1) {
           capacity *= 2;
-          char* new_buf = (char*)malloc(sizeof(char) * capacity);
-          memcpy(new_buf, bytes.buf, bytes.len);
-          free(bytes.buf);
-          bytes.buf = new_buf;
+          bytes.buf = (char*) realloc(bytes.buf, capacity);
         }
 
         bytes.buf[bytes.len++] = get_u24(get_val(ctr.args_buf[0]));


### PR DESCRIPTION
- Adds support for arbitrarily-sized strings and bytes, which lets `READ` and `WRITE` calls work for any size of bytes.
- `book_load` now warns if definitions are too large for the respective runtime.
- removes unused `tm` parameter from global allocation functions for cuda (does this impact runtime b/c of variable stack sizes)?

# Future Work
The rust parser should warn about definition sizes before handing it off to the runtimes.