### PR TITLE
adds dynamic shared mem allocation to cuda kernels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ examples/**/*.cu
 # nix-direnv
 /.direnv/
 /.envrc
+
+# cuda header
+src/shared_mem_config.h

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,3 @@ examples/**/*.cu
 # nix-direnv
 /.direnv/
 /.envrc
-
-# cuda header
-src/shared_mem_config.h

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,5 @@
+use std::process::Command;
+
 fn main() {
   let cores = num_cpus::get();
   let tpcl2 = (cores as f64).log2().floor() as u32;
@@ -6,6 +8,8 @@ fn main() {
   println!("cargo:rerun-if-changed=src/hvm.c");
   println!("cargo:rerun-if-changed=src/run.cu");
   println!("cargo:rerun-if-changed=src/hvm.cu");
+  println!("cargo:rerun-if-changed=src/get_shared_mem.cu");
+  println!("cargo:rerun-if-changed=src/shared_mem_config.h");
   println!("cargo:rustc-link-arg=-rdynamic");
 
   match cc::Build::new()
@@ -23,12 +27,32 @@ fn main() {
   }
 
   // Builds hvm.cu
-  if std::process::Command::new("nvcc").arg("--version").stdout(std::process::Stdio::null()).stderr(std::process::Stdio::null()).status().is_ok() {
+  if Command::new("nvcc").arg("--version").stdout(std::process::Stdio::null()).stderr(std::process::Stdio::null()).status().is_ok() {
     if let Ok(cuda_path) = std::env::var("CUDA_HOME") {
       println!("cargo:rustc-link-search=native={}/lib64", cuda_path);
     } else {
       println!("cargo:rustc-link-search=native=/usr/local/cuda/lib64");
     }
+
+    // Compile get_shared_mem.cu
+    if let Ok(output) = Command::new("nvcc")
+      .args(&["src/get_shared_mem.cu", "-o", "get_shared_mem"])
+      .output()
+      .and_then(|_| Command::new("./get_shared_mem").output()) {
+        if output.status.success() {
+          let shared_mem_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
+          std::fs::write("src/shared_mem_config.h", format!("#define HVM_SHARED_MEM {}", shared_mem_str))
+            .expect("Failed to write shared_mem_config.h");
+          println!("cargo:warning=Shared memory size: {}", shared_mem_str);
+        } else {
+          println!("cargo:warning=\x1b[1m\x1b[31mWARNING: Failed to get shared memory size. Using default value.\x1b[0m");
+        }
+    } else {
+      println!("cargo:warning=\x1b[1m\x1b[31mWARNING: Failed to compile or run get_shared_mem.cu. Using default shared memory value.\x1b[0m");
+    }
+
+    // Clean up temporary executable
+    let _ = std::fs::remove_file("get_shared_mem");
 
     cc::Build::new()
       .cuda(true)

--- a/build.rs
+++ b/build.rs
@@ -43,7 +43,6 @@ fn main() {
           let shared_mem_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
           std::fs::write("src/shared_mem_config.h", format!("#define HVM_SHARED_MEM {}", shared_mem_str))
             .expect("Failed to write shared_mem_config.h");
-          println!("cargo:warning=Shared memory size: {}", shared_mem_str);
         } else {
           println!("cargo:warning=\x1b[1m\x1b[31mWARNING: Failed to get shared memory size. Using default value.\x1b[0m");
         }

--- a/src/get_shared_mem.cu
+++ b/src/get_shared_mem.cu
@@ -1,0 +1,24 @@
+#include <cuda_runtime.h>
+#include <cstdio>
+
+int main() {
+    int device = 0;
+    cudaDeviceProp prop;
+    cudaGetDeviceProperties(&prop, device);
+
+    size_t sharedMemPerBlock = prop.sharedMemPerBlock;
+    int maxSharedMemPerBlockOptin;
+    cudaDeviceGetAttribute(&maxSharedMemPerBlockOptin, cudaDevAttrMaxSharedMemoryPerBlockOptin, device);
+
+    size_t maxSharedMem = (sharedMemPerBlock > (size_t)maxSharedMemPerBlockOptin) ? sharedMemPerBlock : (size_t)maxSharedMemPerBlockOptin;
+
+    // Subtract 3KB (3072 bytes) from the max shared memory as is allocated somewhere else
+    maxSharedMem -= 3072;
+
+    // Calculate the hex value
+    unsigned int hexValue = (unsigned int)(maxSharedMem / 12);
+
+    printf("0x%X", hexValue);
+
+    return 0;
+}

--- a/src/hvm.cu
+++ b/src/hvm.cu
@@ -126,9 +126,15 @@ struct RBag {
   Pair lo_buf[RLEN];
 };
 
+#include "shared_mem_config.h"
+
+#ifndef HVM_SHARED_MEM
+#define HVM_SHARED_MEM 0x2000 // Default value
+#endif
+
 // Local Net
-const u32 L_NODE_LEN = 0x2000;
-const u32 L_VARS_LEN = 0x2000;
+const u32 L_NODE_LEN = HVM_SHARED_MEM;
+const u32 L_VARS_LEN = HVM_SHARED_MEM;
 struct LNet {
   Pair node_buf[L_NODE_LEN];
   Port vars_buf[L_VARS_LEN];

--- a/src/hvm.cu
+++ b/src/hvm.cu
@@ -126,10 +126,9 @@ struct RBag {
   Pair lo_buf[RLEN];
 };
 
-#include "shared_mem_config.h"
-
+// Default value for shared memory (96KB)
 #ifndef HVM_SHARED_MEM
-#define HVM_SHARED_MEM 0x2000 // Default value
+#define HVM_SHARED_MEM 0x2000
 #endif
 
 // Local Net


### PR DESCRIPTION
with this hvm.cu should work virtually on every NVIDIA GPU out there (assuming 5.0 CC and above). it dynamically allocates shared memory based on the GPU's capabilities, specifically 3072 less bytes than the max opt-in shared mem available, as some shared arrays use roughly (a little bit less than) that amount of shared mem.

since shared mem allocation needs to be known at compile time, `get_shared_mem.cu` calculates the available shared mem in build time, which is ran by `build.rs` that then generates a header file `shared_mem_config.h` with the correct hex value for the local net.

Closes: #283 and #314 (supposedly) 