### PR TITLE
Interaction Net graph dumping and visualization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ examples/**/main
 examples/**/*.c
 examples/**/*.cu
 .out.hvm
+dots.js
 
 # nix-direnv
 /.direnv/

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ examples/**/*.c
 examples/**/*.cu
 .out.hvm
 dots.js
+profile.csv
 
 # nix-direnv
 /.direnv/

--- a/README.md
+++ b/README.md
@@ -72,3 +72,34 @@ don't worry, it isn't meant to. [Bend](https://github.com/HigherOrderCO/Bend) is
 the human-readable language and should be used both by end users and by languages
 aiming to target the HVM. If you're looking to learn more about the core
 syntax and tech, though, please check the [PAPER](./paper/HVM2.pdf).
+
+Interaction Net graph dumping and visualization
+-----------------------------------------------
+
+With the rust interpreter (`hvm run`), every evaluation step can be dumped with
+the `--dump` command line option. You can dump in sequential mode (only one
+redex is evaluated in each step) or, with the `--parallel` option,
+in parallel mode (all redexes are evaluated in each step).
+
+The dump will be written to the file `dots.js` in the current directory.
+
+You can view the graph dump with `index.html` as follows:
+
+Copy the file `dots.js` to the HVM directory. Then start a http server in the
+HVM directory:
+
+```sh
+cd HVM
+python3 -m http.server
+```
+
+Now you can visit `http://127.0.0.1:8000` and step through the graph with
+the wasd keys on your keyboard.
+
+How parallel is my Bend/HVM program?
+------------------------------------
+
+With the `--parallel` option, HVM also calculates the average number of regexes
+in each step, thus giving a measurement of how parallel a given bend program is.
+
+You can use the `--parallel` option without the `--dump` option as well.

--- a/README.md
+++ b/README.md
@@ -83,18 +83,9 @@ in parallel mode (all redexes are evaluated in each step).
 
 The dump will be written to the file `dots.js` in the current directory.
 
-You can view the graph dump with `index.html` as follows:
-
-Copy the file `dots.js` to the HVM directory. Then start a http server in the
-HVM directory:
-
-```sh
-cd HVM
-python3 -m http.server
-```
-
-Now you can visit `http://127.0.0.1:8000` and step through the graph with
-the wasd keys on your keyboard.
+You can view the graph dump as follows: Copy the file `dots.js` to the HVM
+directory, then open `index.html` in your browser. You can step through
+the graph with the wasd keys.
 
 How parallel is my Bend/HVM program?
 ------------------------------------
@@ -103,3 +94,6 @@ With the `--parallel` option, HVM also calculates the average number of regexes
 in each step, thus giving a measurement of how parallel a given bend program is.
 
 You can use the `--parallel` option without the `--dump` option as well.
+
+With the `--profile` option, a parallelization profile will be written to
+`profile.csv`. This file contains the number of regexes per step.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<body>
+<style type="text/css">
+    html, body {
+        margin: 0;
+        padding: 0;
+    }
+    #graph {
+        position: absolute;
+        display: block;
+        width: 100%;
+        height: 100%;
+    }
+</style>
+<script src="//d3js.org/d3.v7.min.js"></script>
+<script src="https://unpkg.com/@hpcc-js/wasm@2.20.0/dist/graphviz.umd.js"></script>
+<script src="https://unpkg.com/d3-graphviz@5.6.0/build/d3-graphviz.js"></script>
+<script src="./dots.js"></script>
+<div id="graph"></div>
+<script>
+
+const div = document.getElementById("graph");
+var offset = 0;
+var dotIndex = 0;
+var graphviz = d3.select("#graph").graphviz()
+    .transition(function () {
+        return d3.transition("main")
+            .ease(d3.easeLinear)
+            .duration(120);
+    })
+    .logEvents(false)
+    .width(div.clientWidth)
+    .height(div.clientHeight)
+    .on("initEnd", render);
+
+window.addEventListener("keydown", function (e) {
+    old = offset;
+    if (e.code === "KeyW") {
+        offset = 10;
+    } else if (e.code === "KeyS") {
+        offset = -10;
+    } else if (e.code === "KeyA") {
+        offset = -1;
+    } else if (e.code === "KeyD") {
+        offset = 1;
+    }
+    if (old === 0) {
+        update();
+    }
+});
+
+window.addEventListener("keyup", function (e) {
+    offset = 0;
+});
+
+function render() {
+    graphviz.renderDot(dots[dotIndex]);
+    graphviz.on("end", update);
+}
+
+function update() {
+    if (offset === 0) {
+        return;
+    }
+
+    dotIndex += offset;
+    if (dotIndex < 0) {
+        dotIndex += dots.length;
+    } else if (dotIndex >= dots.length) {
+        dotIndex -= dots.length;
+    }
+    render();
+}
+
+</script>

--- a/index.html
+++ b/index.html
@@ -33,6 +33,10 @@ var graphviz = d3.select("#graph").graphviz()
     .width(div.clientWidth)
     .height(div.clientHeight)
     .fit(false)
+    .tweenPaths(false)
+    .tweenShapes(false)
+    .growEnteringEdges(false)
+    .fade(true)
     .on("initEnd", render);
 
 window.addEventListener("keydown", function (e) {

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
         height: 100%;
     }
 </style>
-<script src="//d3js.org/d3.v7.min.js"></script>
+<script src="https://d3js.org/d3.v7.min.js"></script>
 <script src="https://unpkg.com/@hpcc-js/wasm@2.20.0/dist/graphviz.umd.js"></script>
 <script src="https://unpkg.com/d3-graphviz@5.6.0/build/d3-graphviz.js"></script>
 <script src="./dots.js"></script>
@@ -23,6 +23,7 @@
 const div = document.getElementById("graph");
 var offset = 0;
 var dotIndex = 0;
+readHash();
 var graphviz = d3.select("#graph").graphviz()
     .transition(function () {
         return d3.transition("main")
@@ -59,6 +60,20 @@ window.addEventListener("keyup", function (e) {
     offset = 0;
 });
 
+window.addEventListener("hashchange", function (e) {
+    readHash();
+    render();
+});
+
+function readHash() {
+    if (window.location.hash) {
+        dotIndex = parseInt(window.location.hash.slice(1), 10);
+        if (isNaN(dotIndex)) {
+            dotIndex = 0;
+        }
+    }
+}
+
 function render() {
     graphviz.renderDot(dots[dotIndex]);
     graphviz.on("end", update);
@@ -75,6 +90,7 @@ function update() {
     } else if (dotIndex >= dots.length) {
         dotIndex -= dots.length;
     }
+    window.location.hash = "#" + dotIndex;
     render();
 }
 

--- a/index.html
+++ b/index.html
@@ -27,11 +27,12 @@ var graphviz = d3.select("#graph").graphviz()
     .transition(function () {
         return d3.transition("main")
             .ease(d3.easeLinear)
-            .duration(120);
+            .duration(200);
     })
     .logEvents(false)
     .width(div.clientWidth)
     .height(div.clientHeight)
+    .fit(false)
     .on("initEnd", render);
 
 window.addEventListener("keydown", function (e) {

--- a/src/hvm.rs
+++ b/src/hvm.rs
@@ -454,6 +454,18 @@ impl RBag {
   pub fn len(&self) -> usize {
     self.hi.len()
   }
+
+  pub fn next_eval_idx(&self) -> Option<usize> {
+    if self.hi.len() == 0 {
+      return None;
+    }
+
+    if self.queue {
+      Some(0)
+    } else {
+      Some(self.hi.len() - 1)
+    }
+  }
 }
 
 impl<'a> GNet<'a> {
@@ -1201,8 +1213,22 @@ impl<'a> GNet<'a> {
     s.push_str("}\n");
 
     s.push_str("{\n");
+    s.push_str("edge [dir=both,arrowhead=inv,arrowtail=inv,color=darkviolet]; node [color=darkviolet];\n");
+    {
+      let _i: Option<usize> = rbag.next_eval_idx();
+      if _i.is_some() {
+        let i = _i.unwrap();
+        let pair = &rbag.hi[i];
+        s.push_str(&self.decorate(pair.get_fst(), self.port2node_red(pair.get_fst(), i), book));
+        s.push_str(&self.decorate(pair.get_snd(), self.port2node_red(pair.get_snd(), i), book));
+        s.push_str(&format!("{} -> {};\n", self.port2node_red(pair.get_fst(), i), self.port2node_red(pair.get_snd(), i)));
+      }
+    }
     s.push_str("edge [dir=both,arrowhead=inv,arrowtail=inv,color=red]; node [color=red];\n");
     for (i, pair) in rbag.hi.iter().enumerate() {
+      if i == rbag.next_eval_idx().unwrap() {
+        continue;
+      }
       s.push_str(&self.decorate(pair.get_fst(), self.port2node_red(pair.get_fst(), i), book));
       s.push_str(&self.decorate(pair.get_snd(), self.port2node_red(pair.get_snd(), i), book));
       s.push_str(&format!("{} -> {};\n", self.port2node_red(pair.get_fst(), i), self.port2node_red(pair.get_snd(), i)));

--- a/src/hvm.rs
+++ b/src/hvm.rs
@@ -1065,8 +1065,6 @@ impl RBag {
   }
 }
 
-static mut unique: AtomicU32 = AtomicU32::new(0);
-
 impl<'a> GNet<'a> {
   pub fn show(&self) -> String {
     let mut s = String::new();
@@ -1141,7 +1139,10 @@ impl<'a> GNet<'a> {
   }
 
   fn port2node(&self, port: Port) -> String {
-    return self._port2node(port, format!("unq{}", unsafe {unique.fetch_add(1, Ordering::Relaxed)}));
+    match port.get_tag() {
+        REF | ERA | VAR => panic!("No leaf nodes allowed"),
+        _ => self._port2node(port, "".to_string()),
+    }
   }
 
   fn decorate(&self, port: Port, id: String, book: &Book) -> String {

--- a/src/hvm.rs
+++ b/src/hvm.rs
@@ -1137,7 +1137,7 @@ impl<'a> GNet<'a> {
     let val = port.get_val();
 
     if port == NONE {
-      return format!("{} [shape=box, label=\"NONE\"];\n", id);
+      return format!("{} [shape=diamond, label=\"NONE\"];\n", id);
     }
 
     if port.is_nod() || port.is_var() {
@@ -1145,7 +1145,7 @@ impl<'a> GNet<'a> {
     }
 
     if tag == NUM {
-      return format!("{} [shape=box, label=\"NUM {}\"];\n", id, crate::ast::Numb(Numb(val).0).show());
+      return format!("{} [shape=diamond, label=\"NUM {}\"];\n", id, crate::ast::Numb(Numb(val).0).show());
     } else if tag == ERA {
       return format!("{} [shape=star, label=\"ERA\"];\n", id);
     } else if tag == REF {

--- a/src/hvm.rs
+++ b/src/hvm.rs
@@ -1165,7 +1165,7 @@ impl<'a> GNet<'a> {
       let parent = port.get_val();
       let tag = port.get_tag();
       if tag == OPR {
-        s.push_str(&format!("{} [shape=triangle, label=\"{}\n{}\"];\n", self.port2node(port), crate::ast::Numb(Numb(node.get_fst().get_val()).0).show(), self.port2node(port)));
+        s.push_str(&format!("{} [shape=triangle, label=\"{}\\n{}\"];\n", self.port2node(port), crate::ast::Numb(Numb(node.get_fst().get_val()).0).show(), self.port2node(port)));
       } else {
         s.push_str(&format!("{} [shape=triangle, label=\"{}\"];\n", self.port2node(port), self.port2node(port)));
       }
@@ -1192,7 +1192,7 @@ impl<'a> GNet<'a> {
   pub fn dump(&self, rbag: &RBag, book: &Book) -> String {
     let mut s = String::new();
 
-    s.push_str("strict digraph {\n");
+    s.push_str("strict digraph { ordering=\"out\";\n");
     s.push_str("edge [arrowhead=inv];\n");
 
     s.push_str("{\n");

--- a/src/hvm.rs
+++ b/src/hvm.rs
@@ -107,6 +107,7 @@ pub struct TMem {
   pub itrs: u32, // interaction count
   pub para: Option<f64>, // parallelization factor
   pub dump: Option<String>, // graph dump output
+  pub profile: Option<String>, // parallelization profile
   pub nput: usize, // next node allocation index
   pub vput: usize, // next vars allocation index
   pub nloc: Vec<usize>, // allocated node locations
@@ -573,7 +574,7 @@ impl<'a> Drop for GNet<'a> {
 
 impl TMem {
   // TODO: implement a TMem::new() fn
-  pub fn new(tid: u32, tids: u32, queue: bool, dump: bool) -> Self {
+  pub fn new(tid: u32, tids: u32, queue: bool, dump: bool, profile: bool) -> Self {
     TMem {
       tid,
       tids,
@@ -581,6 +582,7 @@ impl TMem {
       itrs: 0,
       para: None,
       dump: if dump {Some(String::new())} else {None},
+      profile: if profile {Some(String::new())} else {None},
       nput: 0,
       vput: 0,
       nloc: vec![0; 0xFFF], // FIXME: move to a constant
@@ -952,11 +954,19 @@ impl TMem {
 
       let _ = fs::write("dots.js", s);
     }
+
+    if let Some(ref mut s) = self.profile {
+      let _ = fs::write("profile.csv", s);
+    }
   }
 
   fn dump(&mut self, net: &GNet, book: &Book) {
     if let Some(ref mut s) = self.dump {
       s.push_str(&format!("`{}`,\n", net.dump(&self.rbag, book)));
+    }
+
+    if let Some(ref mut s) = self.profile {
+      s.push_str(&format!("{}\n", self.rbag.len()));
     }
   }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -162,7 +162,7 @@ pub fn run(book: &hvm::Book) {
   let net = hvm::GNet::new(1 << 29, 1 << 29);
 
   // Initializes threads
-  let mut tm = hvm::TMem::new(0, 1, false);
+  let mut tm = hvm::TMem::new(0, 1, true);
 
   // Creates an initial redex that calls main
   let main_id = book.defs.iter().position(|def| def.name == "main").unwrap();
@@ -193,4 +193,7 @@ pub fn run(book: &hvm::Book) {
   println!("- ITRS: {}", itrs);
   println!("- TIME: {:.2}s", duration.as_secs_f64());
   println!("- MIPS: {:.2}", itrs as f64 / duration.as_secs_f64() / 1_000_000.0);
+  if tm.para.is_some() {
+    println!("- PARA: {:0.2}", tm.para.unwrap());
+  }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -162,7 +162,7 @@ pub fn run(book: &hvm::Book) {
   let net = hvm::GNet::new(1 << 29, 1 << 29);
 
   // Initializes threads
-  let mut tm = hvm::TMem::new(0, 1);
+  let mut tm = hvm::TMem::new(0, 1, false);
 
   // Creates an initial redex that calls main
   let main_id = book.defs.iter().position(|def| def.name == "main").unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,10 @@ fn main() {
       Command::new("run")
         .about("Interprets a file (using Rust)")
         .arg(Arg::new("file").required(true))
+        .arg(Arg::new("profile")
+          .long("profile")
+          .action(ArgAction::SetTrue)
+          .help("Write parallelization profile to profile.csv"))
         .arg(Arg::new("dump")
           .long("dump")
           .action(ArgAction::SetTrue)
@@ -77,7 +81,7 @@ fn main() {
       let file = sub_matches.get_one::<String>("file").expect("required");
       let code = fs::read_to_string(file).expect("Unable to read file");
       let book = ast::Book::parse(&code).unwrap_or_else(|er| panic!("{}",er)).build();
-      run(&book, *sub_matches.get_one::<bool>("parallel").unwrap(), *sub_matches.get_one::<bool>("dump").unwrap());
+      run(&book, *sub_matches.get_one::<bool>("parallel").unwrap(), *sub_matches.get_one::<bool>("parallel").unwrap(), *sub_matches.get_one::<bool>("dump").unwrap());
     }
     Some(("run-c", sub_matches)) => {
       let file = sub_matches.get_one::<String>("file").expect("required");
@@ -165,12 +169,12 @@ fn main() {
   }
 }
 
-pub fn run(book: &hvm::Book, parallel: bool, dump: bool) {
+pub fn run(book: &hvm::Book, profile: bool, parallel: bool, dump: bool) {
   // Initializes the global net
   let net = hvm::GNet::new(1 << 29, 1 << 29);
 
   // Initializes threads
-  let mut tm = hvm::TMem::new(0, 1, parallel, dump);
+  let mut tm = hvm::TMem::new(0, 1, parallel, dump, profile);
 
   // Creates an initial redex that calls main
   let main_id = book.defs.iter().position(|def| def.name == "main").unwrap();


### PR DESCRIPTION
Hello, we are a student project from the University of Stuttgart and are evaluating Bend.

We started out with implementing some classical algorithms as well as a matrix multiplication to get familiar with Bend. Since Bend is relatively new, instead of asessing absolute performance, we focused on scalability and parallelism instead.

But soon we hit a roadblock: None of our programs "felt" parallel, even programs that should parallelize well in Bend like matrix multiplication or megesort. And worse, there where no indications or debugging tools to tell if the programs really where parallel and, if not, why.

It was clear that we needed proper tools. So we decided to modify the HVM2 rust interpreter to dump the Interaction Net graph in graphviz dot format at every step. We also quickly hacked together a viewer in html and javascript to be able to step trough the graph dumps.

Our modification is able to dump the graph in sequential mode (only one redex is evaluated in each step) or in parallel mode (all redexes are evaluated in each step). In parallel mode, it also calculates the average number of regexes in each step, thus giving a measurement of how parallel a given bend program is.

You can see some Interaction Nets here, use the wasd Keys to step through the visualizations: http://w3studi.informatik.uni-stuttgart.de/~straubls/